### PR TITLE
Add CNN Architecture and Training Process Tutorial

### DIFF
--- a/AI-ML Documentation/Tutorials/Architecture_Of_CNN.md
+++ b/AI-ML Documentation/Tutorials/Architecture_Of_CNN.md
@@ -1,0 +1,51 @@
+## Convolutional Neural Network (CNN) Architecture and Training Process
+
+A **Convolutional Neural Network (CNN)** is a specialized type of deep neural network, primarily used for image recognition, but also effective in tasks such as video processing and natural language processing.
+
+### Architecture of CNN:
+
+1. **Input Layer**:
+   - Accepts an image (usually represented as a matrix of pixel values). For colored images, the input is a 3D matrix with dimensions (height, width, depth (RGB channels)).
+
+2. **Convolutional Layers**:
+   - Applies **convolutional filters** (kernels) to the input to detect features like edges and patterns. Each filter slides over the image (or feature map from the previous layer) and performs element-wise multiplication and sum to generate a feature map.
+   - Different filters detect different aspects of the image, such as edges, corners, or more complex features in deeper layers.
+
+3. **Activation Function (ReLU)**:
+   - After each convolution, the **Rectified Linear Unit (ReLU)** is applied to add non-linearity to the model, allowing it to learn more complex patterns. ReLU replaces all negative values in the feature map with zero.
+
+4. **Pooling Layer**:
+   - **Pooling** reduces the spatial dimensions (height and width) of the feature maps, retaining essential information while reducing computational load. The most common type is **max pooling**.
+   - Pooling helps make the CNN invariant to small translations of the image (i.e., shifting the image slightly won’t affect the output much).
+
+5. **Fully Connected Layer (FC)**:
+   - After several convolutional and pooling layers, fully connected layers perform high-level reasoning. Every neuron in the fully connected layer is connected to every neuron in the previous layer.
+
+6. **Output Layer**:
+   - In classification tasks, the output layer is typically a **softmax layer**, providing probabilities for each class. The class with the highest probability is the predicted class.
+
+### Training Process of CNN:
+
+1. **Forward Propagation**:
+   - The input image passes through the layers (convolution, activation, pooling, fully connected) to produce an output (class probabilities or prediction).
+
+2. **Loss Calculation**:
+   - A **loss function** (e.g., cross-entropy for classification tasks) calculates the difference between the predicted output and the actual label of the image.
+
+3. **Backpropagation**:
+   - The **gradient of the loss function** with respect to each weight is calculated. Gradients are propagated backward through the network, including through convolutional layers, to update weights.
+
+4. **Weight Update (Optimization)**:
+   - Using an optimizer like **Stochastic Gradient Descent (SGD)** or **Adam**, the weights are updated to minimize the loss. This step repeats over many iterations, refining the filters and weights.
+
+5. **Iterations and Epochs**:
+   - The training process is repeated over several **epochs**, where each epoch represents one complete pass through the dataset. The CNN progressively learns better features over time.
+
+6. **Regularization Techniques**:
+   - To prevent overfitting, techniques like **dropout** (randomly setting a fraction of neurons to zero during training) and **data augmentation** (applying transformations to input images) are used.
+
+### Summary:
+- **CNNs** automatically learn spatial hierarchies of features from data.
+- **Convolutional layers** extract important features from images.
+- **Pooling layers** down-sample the feature maps, reducing the computational cost.
+- The network is trained using **backpropagation** and optimization algorithms to adjust filters and weights.

--- a/AI-ML Documentation/Tutorials/Readme.md
+++ b/AI-ML Documentation/Tutorials/Readme.md
@@ -4,6 +4,8 @@ Document the process of training and evaluating a simple linear regression model
 
 2.Deep Learning: 
 Explain the architecture and training process of a convolutional neural network (CNN).
+Refer [this document](Tutorials/Architecture_Of_CNN.md).
+
 
 3.Deployment: 
 Steps to deploy a machine learning model using Flask or FastAPI.


### PR DESCRIPTION
This PR adds a new tutorial on **Convolutional Neural Networks (CNN)**, covering both the architecture and training process.

**Key Changes:**

- Added Architecture_Of_CNN.md in the Tutorials folder.
- Detailed explanation of the CNN architecture, including:
- Input Layer
- Convolutional Layers
- Activation Functions (ReLU)
- Pooling Layers
- Fully Connected Layers
- Output Layer
- Outlined the training process for CNNs, including:
- Forward Propagation
- Loss Calculation
- Backpropagation
- Weight Update
- Regularization Techniques
- Purpose

This tutorial aims to provide a comprehensive understanding of how CNNs work and how to train them effectively, catering to both beginners and those looking to refresh their knowledge in deep learning.

Please review and consider merging this addition to enhance the repository's educational resources.